### PR TITLE
:wrench: Add OSX and Linux setup file

### DIFF
--- a/setup-osx.sh
+++ b/setup-osx.sh
@@ -1,0 +1,35 @@
+
+# Copy files.
+echo "Copying configuration files ...."
+
+# Copy glassfish-resources.xml
+mkdir -p Logica/setup
+cp config-files/logica/setup/glassfish-resources.xml Logica/setup/
+echo "Copied logica/setup/glassfish-resources.xml"
+
+# Copy persistence.xml
+mkdir -p Logica/src/conf
+cp config-files/logica/src/conf/persistence.xml Logica/src/conf/persistence.xml
+echo "Copied logica/src/conf/persistence.xml"
+
+# Copy glassfish-resources.xml
+mkdir -p Logica/web/WEB-INF/
+cp config-files/logica/web/WEB-INF/glassfish-resources.xml Logica/web/WEB-INF/glassfish-resources.xml
+echo "Copied logica/web/WEB-INF/glassfish-resources.xml"
+
+# Copy private.xml
+mkdir -p Presentacion/nbproject/private/
+cp config-files/presentacion/nbproject/private/private.xml Presentacion/nbproject/private/
+echo "Copied presentacion/nbproject/private/private.xml"
+
+# Copy project.properties
+mkdir -p Logica/nbproject/
+cp config-files/logica/nbproject/project.properties Logica/nbproject/project.properties
+echo "Copied Logica/nbproject/project.properties"
+
+# Copy project.properties
+mkdir -p Presentacion/nbproject
+cp -p config-files/presentacion/nbproject/project.properties Presentacion/nbproject/project.properties
+echo "Copied Presentacion/nbproject/project.properties"
+
+echo "Finished copying configuration files"


### PR DESCRIPTION
Add setup file for **OSX** and **Linux**.

This setup file will copy all necesary configuration files to their proper location.

In order to run the script just do:

``` bash
# Clone repository if not cloned already.
git clone https://github.com/poligrancol/gestiondocente.git

# Change directory into project.
cd gestiondocente

# Run setup script.
sh setup-osx.sh
```

Note: We are missing the port of this bash script for windows.

cc: @jolarter @Gdaimon 
